### PR TITLE
:SMALL: ARCEM-4516 - Make sure debug statements are not written in production apps

### DIFF
--- a/Baymax/Logger/Logger.swift
+++ b/Baymax/Logger/Logger.swift
@@ -9,13 +9,14 @@
 import Foundation
 import os.log
 
-/// Logs a string to a given instance of `Log`
+/// Logs a formatted message.
+///
 /// - Parameters:
-///   - message: The message to be logged
-///   - subsystem: The subsystem of the log (Defaults to Bundle.main.bundleIdentifier)
-///   - category: The category of the log
-///   - log: The log to append to
-///   - type: The type of the log
+///   - message: The content to log.
+///   - subsystem: Log subsystem (defaults to `Bundle.main.bundleIdentifier`).
+///   - category: Log category (defaults to `"Default"`).
+///   - log: The `Logger` instance to write to.
+///   - type: The log type (e.g. `.debug`, `.error`, etc.).
 public func baymax_log(
     _ message: String,
     subsystem: String = Bundle.main.bundleIdentifier ?? "",
@@ -25,6 +26,15 @@ public func baymax_log(
 ) {
     let constructedMessage = "[\(type.rawValue.uppercased())] | \(subsystem) (\(category)) | \(message)"
     var _log = log
+
+    // Only run debug logs if the user is debugging.
+    // These logs should not happen in production code.
+    if type == .debug {
+        #if !DEBUG
+        return
+        #endif
+    }
+
     print(constructedMessage, to: &_log)
 }
 


### PR DESCRIPTION
## What?

- Omit debug logs from production builds
- The DEBUG flag should respect the parent project's debug compile flag
- This is to help stop pushing any sensitive logs to production

We're already doing this on FA, and rather than doing this separately on Emergency, we may as well pop this into the Baymax project.

Intended use:
Developers should send a debug log to Baymax when logging anything like:
- REST requests/responses
- DB Interations
- Sensitive user data (ideally these logs should be completely deleted)

## Why?

https://3sidedcube.atlassian.net/browse/ARCEM-4516

Here's what we're doing in FA already:

```
extension BaymaxLogType {
    func log(
        _ log: String,
        category: String = "App"
    ) {
        if self == .debug {
            #if DEBUG
            executeLog(log, category: category)
            #endif
        } else {
            executeLog(log, category: category)
        }
    }

    private func executeLog(
        _ log: String,
        category: String = "App"
    ) {
        baymax_log(
            log,
            subsystem: Bundle.main.bundleIdentifier ?? "",
            category: category,
            type: self
        )
    }
}
```